### PR TITLE
[FIX] report_aeroo: increased sequence for compatibility with other modules

### DIFF
--- a/report_aeroo/static/src/js/report/reportactionmanager.js
+++ b/report_aeroo/static/src/js/report/reportactionmanager.js
@@ -46,4 +46,4 @@ async function aerooReportHandler (action, options, env){
     }
 }
 
-registry.category("ir.actions.report handlers").add("aeroo_handler", aerooReportHandler);
+registry.category("ir.actions.report handlers").add("aeroo_handler", aerooReportHandler, { sequence: 99 });


### PR DESCRIPTION
Cuando se llaman a los handlers de ir.actions.report (estos ordenados por secuencia) si primero se llama al de aeroo_report y luego se llama al de report_substitute (y este se sustituye un reporte por otro de aeroo) no hace nada y da un error al querer imprimir ya que ya se ha llamado antes al de aeroo_report.
![image](https://github.com/user-attachments/assets/45e473de-1335-46e3-a808-fbf66c5170d0)
