### PR TITLE
[FIX] report_aeroo: avoid display_name write when rendering records

### DIFF
--- a/report_aeroo/__manifest__.py
+++ b/report_aeroo/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     "name": "Aeroo Reports",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.0.1",
     "category": "Generic Modules/Aeroo Reports",
     "summary": "Enterprise grade reporting solution",
     "author": "Alistek",  # pylint: disable=manifest-required-author

--- a/report_aeroo/report_parser.py
+++ b/report_aeroo/report_parser.py
@@ -103,7 +103,9 @@ class ReportAerooAbstract(models.AbstractModel):
 
     def __filter(self, val):
         if isinstance(val, models.BaseModel) and val:
-            return val._compute_display_name()
+            # Leemos display_name; llamar _compute_display_name() directo dispara
+            # un write() real que rompe con usuarios sin permiso (p. ej. res.country).
+            return val[:1].display_name
         return _filter(val)
 
     # Extra Functions ==================================================


### PR DESCRIPTION
## Problem

`report_aeroo` renders every `${...}` expression through `__filter`. For recordset values it called `_compute_display_name()` **directly**:

```python
return val._compute_display_name()
```

Calling the compute method outside the ORM compute protocol makes the `record.display_name = ...` assignment take `Field.__set__`'s business-logic branch (`odoo/fields.py`), which issues a **real `write()`** on the rendered model instead of only updating the cache.

Consequences:

- Printing an aeroo report as a user **without write access** on the rendered model raises `AccessError`. This surfaced when a non-admin printed a report that renders a `res.country` record (e.g. `${o.partner_id.country_id}`) — `res.country` is writable only by the Settings group. It only reproduced when the report was rendered as the acting user (e.g. IoT printing via `render_and_send`), not through channels that render elevated.
- The method returns `None`, so the record was rendered empty.

Regression introduced in `fa94921` (migration of `name_get()[0][1]` → `_compute_display_name()`).

## Fix

Read `display_name` (computed into cache, no write), restoring the original `name_get()[0][1]` semantics:

```python
return val[:1].display_name
```

## How to verify

Render an aeroo report that outputs a record (e.g. `${o.partner_id.country_id}`) as a user **without** write access on that model (non-admin, no Settings group). Before: `AccessError` on `res.country` and the value rendered empty. After: renders the display name, no write.

Ref: https://www.adhoc.inc/odoo/helpdesk.ticket/122297
